### PR TITLE
Fix C23 build failures using GCC 15

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -45,7 +45,7 @@ unblock (void)
 }
 
 static void
-install_signal (int signum, RETSIGTYPE (*handler) ())
+install_signal (int signum, RETSIGTYPE (*handler) (int))
 /* Emulate the `signal' function via `sigaction'.  */
 {
   struct sigaction  action;


### PR DESCRIPTION
Building moon-buggy v1.0.51 using GCC 15 (C23) on Fedora Rawhide without this patch fails like this:

```
gcc -DHAVE_CONFIG_H -I.     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection  -c -o signal.o signal.c
make[1]: Leaving directory '/builddir/build/BUILD/moon-buggy-1.0.51-build/moon-buggy-1.0.51'
signal.c: In function ‘install_signal’:
signal.c:56:21: error: assignment to ‘__sighandler_t’ {aka ‘void (*)(int)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
   56 |   action.sa_handler = handler;
      |                     ^
In file included from signal.c:12:
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```